### PR TITLE
Fix `Project::project_access`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 - **[Fix]** Fix `Project::shared_with_groups` type.
+- **[Fix]** Fix `ProjectPermissions::project_access` type (it can be `null`).
 
 # 0.14.0
 

--- a/src/common/project.rs
+++ b/src/common/project.rs
@@ -267,7 +267,7 @@ pub struct ContainerExpirationPolicy {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProjectPermissions {
-  pub project_access: ProjectAccess,
+  pub project_access: Option<ProjectAccess>,
   pub group_access: Option<CompactString>,
 }
 


### PR DESCRIPTION
This previously required the value to be set, but `null` is allowed.